### PR TITLE
Allow custom server certificate source

### DIFF
--- a/Kestrel.HttpsCertificateSelection.AzureKeyVault/Kestrel.HttpsCertificateSelection.AzureKeyVault.csproj
+++ b/Kestrel.HttpsCertificateSelection.AzureKeyVault/Kestrel.HttpsCertificateSelection.AzureKeyVault.csproj
@@ -12,10 +12,10 @@
 		<Authors>mataness</Authors>
 		<AssemblyName>Kestrel.HttpsCertificateSelection.AzureKeyVault</AssemblyName>
 		<RootNamespace>Kestrel.HttpsCertificateSelection.AzureKeyVault</RootNamespace>
-		<Version>2.0.0</Version>
+		<Version>2.1.0</Version>
 		<PackageReleaseNotes>
-			Changing the local store certificate options to allow searching the cert store with FindValue and FindType
-		</PackageReleaseNotes>
+      Allowing for custom IServerCertificateSource implementation to be used for retrieval of the certificate from the local store
+    </PackageReleaseNotes>
   </PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.2.0" />

--- a/Kestrel.HttpsCertificateSelection/CertificateSelection/Configuration/ServerLocalCertificateStoreConfigurationOptions.cs
+++ b/Kestrel.HttpsCertificateSelection/CertificateSelection/Configuration/ServerLocalCertificateStoreConfigurationOptions.cs
@@ -7,10 +7,10 @@ namespace Kestrel.HttpsCertificateSelection.CertificateSelection.Configuration
     /// </summary>
     public class ServerLocalCertificateStoreConfigurationOptions : ServerCertificateConfigurationOptionsBase
     {
-        /// <summary>
-        /// Required - the find value of the certificate to fetch from the local certificate store. See <see cref="X509Certificate2Collection.Find(X509FindType, object, bool)"/>
-        /// </summary>
-        public string FindValue { get; set; }
+		/// <summary>
+		/// Required (if <see cref="ServerCertificateSource"/> isn't provided) - the find value of the certificate to fetch from the local certificate store. See <see cref="X509Certificate2Collection.Find(X509FindType, object, bool)"/>
+		/// </summary>
+		public string FindValue { get; set; }
 
         /// <summary>
         /// The find type, defaults to <see cref="X509FindType.FindBySubjectName"/>. See <see cref="X509FindType"/>
@@ -18,8 +18,15 @@ namespace Kestrel.HttpsCertificateSelection.CertificateSelection.Configuration
         public X509FindType FindType { get; set; } = X509FindType.FindBySubjectName;
 
         /// <summary>
-        /// Required - the store location, defaults to <see cref="StoreLocation.LocalMachine"/>
+        /// Required (if <see cref="ServerCertificateSource"/> isn't provided) - the store location, defaults to <see cref="StoreLocation.LocalMachine"/>
         /// </summary>
         public StoreLocation Location { get; set; } = StoreLocation.LocalMachine;
+
+        /// <summary>
+        /// Optional - server certificate source for when the retrieval options above aren't sufficient and a more specific search is needed.
+        /// If instance is provided, the <see cref="FindType"/>, <see cref="FindValue"/> and <see cref="Local"/> will be ignored and its
+        /// <see cref="IServerCertificateSource.GetLatestCertificateAsync(bool)"/> implementation will be used to retrieve the server certificate.
+        /// </summary>
+        public IServerCertificateSource ServerCertificateSource { get; set; }
     }
 }

--- a/Kestrel.HttpsCertificateSelection/HttpsConnectionAdapterOptionsExtensions.cs
+++ b/Kestrel.HttpsCertificateSelection/HttpsConnectionAdapterOptionsExtensions.cs
@@ -49,13 +49,12 @@ namespace Kestrel.HttpsCertificateSelection
                 var options = new ServerLocalCertificateStoreConfigurationOptions();
                 configOptions(options);
 
-                var serverCertificateProvider = new LocalStoreServerCertificateSource(options.FindValue, options.FindType, new LocalCertificateStoreReader(options.Location), new X509CertificateAnalyzer());
                 serverConfigOptions.ValidCertificatesOnly = options.ValidCertificatesOnly;
                 serverConfigOptions.PollingInterval = options.PollingInterval;
                 serverConfigOptions.SelectorConfigureOptions = options.SelectorConfigureOptions;
-                serverConfigOptions.ServerCertificateSource = serverCertificateProvider;
+                serverConfigOptions.ServerCertificateSource = options.ServerCertificateSource ?? new LocalStoreServerCertificateSource(options.FindValue, options.FindType, new LocalCertificateStoreReader(options.Location), new X509CertificateAnalyzer());
             });
         }
-    }
+	}
 
 }

--- a/Kestrel.HttpsCertificateSelection/Kestrel.HttpsCertificateSelection.csproj
+++ b/Kestrel.HttpsCertificateSelection/Kestrel.HttpsCertificateSelection.csproj
@@ -18,9 +18,9 @@
 		<Author>mataness</Author>
 		<AssemblyName>Kestrel.HttpsCertificateSelection</AssemblyName>
 		<RootNamespace>Kestrel.HttpsCertificateSelection</RootNamespace>
-		<Version>2.0.0</Version>
+		<Version>2.1.0</Version>
 		<PackageReleaseNotes>
-			Changing the local store certificate options to allow searching the cert store with FindValue and FindType
+			Allowing for custom IServerCertificateSource implementation to be used for retrieval of the certificate from the local store
 		</PackageReleaseNotes>
 	</PropertyGroup>
 


### PR DESCRIPTION
The implementation of LocalStoreServerCertificateSource allows basic configuration driven retrieval of the certificate from the local store. For more complex/specific retrieval via additional linq filtering or ordering we could expose additional properties, but for a full control it would be nice to let the consumers provide their own implementation of the IServerCertificateSource and use that for retrieval instead.